### PR TITLE
Fix API key URL encoding in daily notifications workflow

### DIFF
--- a/.github/workflows/daily-notifications.yml
+++ b/.github/workflows/daily-notifications.yml
@@ -12,7 +12,9 @@ jobs:
       - name: Trigger notification function
         run: |
           # Send both email and push notifications
-          RESPONSE=$(curl -X POST "https://us-central1-${{ secrets.FIREBASE_PROJECT_ID }}.cloudfunctions.net/sendDailyTaskReminders?key=${{ secrets.NOTIFICATION_API_KEY }}&sendPush=true" -s)
+          # URL encode the API key to handle special characters
+          API_KEY=$(echo -n "${{ secrets.NOTIFICATION_API_KEY }}" | perl -MURI::Escape -ne 'print uri_escape($_)')
+          RESPONSE=$(curl -X POST "https://us-central1-${{ secrets.FIREBASE_PROJECT_ID }}.cloudfunctions.net/sendDailyTaskReminders?key=${API_KEY}&sendPush=true" -s)
           echo "Function response: $RESPONSE"
           if [[ "$RESPONSE" == *"Sent notifications"* || "$RESPONSE" == *"No tasks due today"* ]]; then
             echo "✅ Notifications processed successfully"


### PR DESCRIPTION
This PR fixes the daily notifications workflow by properly URL encoding the API key. This is necessary because the API key contains special characters like '+' and '/' that need to be encoded in URLs.